### PR TITLE
Parsing

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -20,6 +20,7 @@ void parser(char *input)
 		if (execve(argv[0], argv, NULL) == -1)
 		{
 			write(STDOUT_FILENO, "Not found\n", 10);
+			exit(0);
 		}
 	}
 	else
@@ -52,7 +53,7 @@ int main(void)
 		write(STDOUT_FILENO, "$ ", 2);
 		gl_check = getline(&buf, &buf_size, stdin);
 	}
-	write(1, "\n", 1);
 	free(buf);
+	write(STDOUT_FILENO, "\n", 1);
 	return (0);
 }

--- a/shell.c
+++ b/shell.c
@@ -8,7 +8,7 @@
 
 void parser(char *input)
 {
-	const char *delims = " \n\t";
+	const char *delims = " \n\t\r\v\f";
 	char *argv[2] = {NULL, NULL};
 	int status;
 	pid_t child;
@@ -52,6 +52,7 @@ int main(void)
 		write(STDOUT_FILENO, "$ ", 2);
 		gl_check = getline(&buf, &buf_size, stdin);
 	}
+	write(1, "\n", 1);
 	free(buf);
 	return (0);
 }


### PR DESCRIPTION
Hey @JamesPagani 

Added exit(0) at the child process in the parse function. There was a memory allocation and when typing ctrl-d the shell didn't exit until it had released whatever was allocated in memory.

Example:
![memory](https://user-images.githubusercontent.com/7443480/69486253-f96e1800-0e17-11ea-9027-91bac5397bb3.png)

Take a look at the commit and see what I added it. Will keep on adding stuff.